### PR TITLE
Remove text-align: justify

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -88,5 +88,4 @@ p {
 .art-presentation h1 {
   font-weight: 300;
   font-size: 2.2em;
-  text-align: justify;
 }


### PR DESCRIPTION
Why did you use this? If for no real reason, merge this please. I don't see any justified text on the original site.